### PR TITLE
Fix: Java commands do not work with space in path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-    "version": "0.2.8",
+    "version": "0.2.9",
     "configurations": [
         {
             "name": "Launch Extension",

--- a/.vsixmanifest
+++ b/.vsixmanifest
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
     xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Language="en-US" Id="compstruct-vscode" Version="0.2.8" Publisher="jamestiotio"/>
+        <Identity Language="en-US" Id="compstruct-vscode" Version="0.2.9" Publisher="jamestiotio"/>
         <DisplayName>CompStruct VSCode</DisplayName>
         <Description xml:space="preserve">VSCode Extension for Computation Structures Courseware (jsim, tmsim, bsim)</Description>
         <Tags>jsim,bsim,tmsim,JSim,BSim,TMSim,__ext_.jsim,__ext_.uasm,__ext_.tmsim</Tags>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "compstruct-vscode" extension will be documented in t
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.2.9]
+-   Fix `.jar` not found for some users due to whitespace in path
+
 ## [0.2.8]
 
 -   Added commands to run JSim and BSim with currently opened file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "compstruct-vscode",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "compstruct-vscode",
     "displayName": "CompStruct VSCode",
     "description": "VSCode Extension for Computation Structures Courseware (jsim, tmsim, bsim)",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "publisher": "jamestiotio",
     "homepage": "https://github.com/jamestiotio/compstruct-vscode",
     "author": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ async function findJarAndRun(uri: vscode.Uri, jarname: string) {
         // Get filename of current file
         const filepath = vscode.window.activeTextEditor?.document.uri.fsPath;
         if (!filepath) {
-            terminal?.sendText(`java -jar ${jarUri.fsPath}`);
+            terminal?.sendText(`java -jar "${jarUri.fsPath}"`);
         } else {
             // Get the extension of the current file
             const extension = filepath.split('.').pop();
@@ -56,7 +56,7 @@ async function findJarAndRun(uri: vscode.Uri, jarname: string) {
                     );
                 }
             }
-            terminal?.sendText(`java -jar ${jarUri.fsPath} ${filepath}`);
+            terminal?.sendText(`java -jar "${jarUri.fsPath}" "${filepath}"`);
         }
 
         return true;


### PR DESCRIPTION
Added quotes to allow command to work with spaces in path. Updated version to 0.2.9